### PR TITLE
Use Kinobi IDL directly

### DIFF
--- a/program/idl.json
+++ b/program/idl.json
@@ -1,82 +1,230 @@
 {
-  "version": "0.0.1",
-  "name": "compute_budget",
-  "instructions": [
-    {
-      "name": "requestUnits",
-      "accounts": [],
-      "discriminant": { "value": 0, "type": "u8" },
-      "args": [
-        {
-          "name": "units",
-          "type": "u32",
-          "docs": ["Units to request for transaction-wide compute."]
-        },
-        {
-          "name": "additionalFee",
-          "type": "u32",
-          "docs": ["Prioritization fee lamports."]
-        }
-      ]
-    },
-    {
-      "name": "requestHeapFrame",
-      "accounts": [],
-      "discriminant": { "value": 1, "type": "u8" },
-      "args": [
-        {
-          "name": "bytes",
-          "type": "u32",
-          "docs": [
-            "Requested transaction-wide program heap size in bytes.",
-            "Must be multiple of 1024. Applies to each program, including CPIs."
-          ]
-        }
-      ]
-    },
-    {
-      "name": "setComputeUnitLimit",
-      "accounts": [],
-      "discriminant": { "value": 2, "type": "u8" },
-      "args": [
-        {
-          "name": "units",
-          "type": "u32",
-          "docs": ["Transaction-wide compute unit limit."]
-        }
-      ]
-    },
-    {
-      "name": "setComputeUnitPrice",
-      "accounts": [],
-      "discriminant": { "value": 3, "type": "u8" },
-      "args": [
-        {
-          "name": "microLamports",
-          "type": "u64",
-          "docs": [
-            "Transaction compute unit price used for prioritization fees."
-          ]
-        }
-      ]
-    },
-    {
-      "name": "setLoadedAccountsDataSizeLimit",
-      "accounts": [],
-      "args": [
-        {
-          "name": "accountDataSizeLimit",
-          "type": "u32"
-        }
-      ],
-      "discriminant": {
-        "type": "u8",
-        "value": 4
+  "kind": "rootNode",
+  "program": {
+    "kind": "programNode",
+    "pdas": [],
+    "accounts": [],
+    "instructions": [
+      {
+        "kind": "instructionNode",
+        "accounts": [],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "discriminator",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "docs": [],
+            "defaultValue": { "kind": "numberValueNode", "number": 0 },
+            "defaultValueStrategy": "omitted"
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "units",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            },
+            "docs": ["Units to request for transaction-wide compute."]
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "additionalFee",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            },
+            "docs": ["Prioritization fee lamports."]
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "fieldDiscriminatorNode",
+            "name": "discriminator",
+            "offset": 0
+          }
+        ],
+        "name": "requestUnits",
+        "idlName": "requestUnits",
+        "docs": [],
+        "optionalAccountStrategy": "programId"
+      },
+      {
+        "kind": "instructionNode",
+        "accounts": [],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "discriminator",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "docs": [],
+            "defaultValue": { "kind": "numberValueNode", "number": 1 },
+            "defaultValueStrategy": "omitted"
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "bytes",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            },
+            "docs": [
+              "Requested transaction-wide program heap size in bytes.",
+              "Must be multiple of 1024. Applies to each program, including CPIs."
+            ]
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "fieldDiscriminatorNode",
+            "name": "discriminator",
+            "offset": 0
+          }
+        ],
+        "name": "requestHeapFrame",
+        "idlName": "requestHeapFrame",
+        "docs": [],
+        "optionalAccountStrategy": "programId"
+      },
+      {
+        "kind": "instructionNode",
+        "accounts": [],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "discriminator",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "docs": [],
+            "defaultValue": { "kind": "numberValueNode", "number": 2 },
+            "defaultValueStrategy": "omitted"
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "units",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            },
+            "docs": ["Transaction-wide compute unit limit."]
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "fieldDiscriminatorNode",
+            "name": "discriminator",
+            "offset": 0
+          }
+        ],
+        "name": "setComputeUnitLimit",
+        "idlName": "setComputeUnitLimit",
+        "docs": [],
+        "optionalAccountStrategy": "programId"
+      },
+      {
+        "kind": "instructionNode",
+        "accounts": [],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "discriminator",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "docs": [],
+            "defaultValue": { "kind": "numberValueNode", "number": 3 },
+            "defaultValueStrategy": "omitted"
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "microLamports",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            },
+            "docs": [
+              "Transaction compute unit price used for prioritization fees."
+            ]
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "fieldDiscriminatorNode",
+            "name": "discriminator",
+            "offset": 0
+          }
+        ],
+        "name": "setComputeUnitPrice",
+        "idlName": "setComputeUnitPrice",
+        "docs": [],
+        "optionalAccountStrategy": "programId"
+      },
+      {
+        "kind": "instructionNode",
+        "accounts": [],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "discriminator",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "docs": [],
+            "defaultValue": { "kind": "numberValueNode", "number": 4 },
+            "defaultValueStrategy": "omitted"
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "accountDataSizeLimit",
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u32",
+              "endian": "le"
+            },
+            "docs": []
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "fieldDiscriminatorNode",
+            "name": "discriminator",
+            "offset": 0
+          }
+        ],
+        "name": "setLoadedAccountsDataSizeLimit",
+        "idlName": "setLoadedAccountsDataSizeLimit",
+        "docs": [],
+        "optionalAccountStrategy": "programId"
       }
-    }
-  ],
-  "metadata": {
-    "address": "ComputeBudget111111111111111111111111111111",
+    ],
+    "definedTypes": [],
+    "errors": [],
+    "name": "computeBudget",
+    "prefix": "",
+    "publicKey": "ComputeBudget111111111111111111111111111111",
+    "version": "0.0.1",
     "origin": "shank"
-  }
+  },
+  "additionalPrograms": [],
+  "standard": "kinobi",
+  "version": "0.19.0"
 }

--- a/scripts/generate-clients.mjs
+++ b/scripts/generate-clients.mjs
@@ -4,8 +4,8 @@ import * as k from "@metaplex-foundation/kinobi";
 import { workingDirectory } from "./utils.mjs";
 
 // Instanciate Kinobi.
-const kinobi = k.createFromIdl(
-  path.join(workingDirectory, "program", "idl.json")
+const kinobi = k.createFromRoot(
+  require(path.join(workingDirectory, "program", "idl.json"))
 );
 
 // Render JavaScript.


### PR DESCRIPTION
This PR uses a Kinobi IDL directly instead of importing and transforming an Anchor/Shank IDL.