### PR TITLE
Add compute unit helpers

### DIFF
--- a/clients/js/src/constants.ts
+++ b/clients/js/src/constants.ts
@@ -1,0 +1,12 @@
+/**
+ * A provisory compute unit limit is used to indicate that the transaction
+ * should be estimated for compute units before being sent to the network.
+ *
+ * Setting it to zero ensures the transaction fails unless it is properly estimated.
+ */
+export const PROVISORY_COMPUTE_UNIT_LIMIT = 0;
+
+/**
+ * The maximum compute unit limit that can be set for a transaction.
+ */
+export const MAX_COMPUTE_UNIT_LIMIT = 1_400_000;

--- a/clients/js/src/estimateAndSetComputeLimit.ts
+++ b/clients/js/src/estimateAndSetComputeLimit.ts
@@ -1,0 +1,65 @@
+import {
+  CompilableTransactionMessage,
+  ITransactionMessageWithFeePayer,
+  TransactionMessage,
+} from '@solana/kit';
+import {
+  MAX_COMPUTE_UNIT_LIMIT,
+  PROVISORY_COMPUTE_UNIT_LIMIT,
+} from './constants';
+import {
+  EstimateComputeUnitLimitFactoryFunction,
+  EstimateComputeUnitLimitFactoryFunctionConfig,
+} from './estimateComputeLimitInternal';
+import { getSetComputeUnitLimitInstructionIndexAndUnits } from './internal';
+import { updateOrAppendSetComputeUnitLimitInstruction } from './setComputeLimit';
+
+type EstimateAndUpdateProvisoryComputeUnitLimitFactoryFunction = <
+  TTransactionMessage extends
+    | CompilableTransactionMessage
+    | (TransactionMessage & ITransactionMessageWithFeePayer),
+>(
+  transactionMessage: TTransactionMessage,
+  config?: EstimateComputeUnitLimitFactoryFunctionConfig
+) => Promise<TTransactionMessage>;
+
+/**
+ * Given a transaction message, if it does not have an explicit compute unit limit,
+ * estimates the compute unit limit and updates the transaction message with
+ * the estimated limit. Otherwise, returns the transaction message unchanged.
+ *
+ * It requires a function that estimates the compute unit limit.
+ *
+ * @example
+ * ```ts
+ * const estimateComputeUnitLimit = estimateComputeUnitLimitFactory({ rpc });
+ * const estimateAndUpdateProvisoryComputeUnitLimit =
+ *   estimateAndUpdateProvisoryComputeUnitLimitFactory(estimateComputeUnitLimit);
+ * const estimatedTransactionMessage =
+ *   await estimateAndUpdateProvisoryComputeUnitLimit(transactionMessage)
+ * ```
+ */
+export function estimateAndUpdateProvisoryComputeUnitLimitFactory(
+  estimateComputeUnitLimit: EstimateComputeUnitLimitFactoryFunction
+): EstimateAndUpdateProvisoryComputeUnitLimitFactoryFunction {
+  return async function fn(transactionMessage, config) {
+    const instructionDetails =
+      getSetComputeUnitLimitInstructionIndexAndUnits(transactionMessage);
+
+    // If the transaction message already has a compute unit limit instruction
+    // which is set to a specific value — i.e. not 0 or the maximum limit —
+    // we don't need to estimate the compute unit limit.
+    if (
+      instructionDetails &&
+      instructionDetails.units !== PROVISORY_COMPUTE_UNIT_LIMIT &&
+      instructionDetails.units !== MAX_COMPUTE_UNIT_LIMIT
+    ) {
+      return transactionMessage;
+    }
+
+    return updateOrAppendSetComputeUnitLimitInstruction(
+      await estimateComputeUnitLimit(transactionMessage, config),
+      transactionMessage
+    );
+  };
+}

--- a/clients/js/src/estimateAndSetComputeLimit.ts
+++ b/clients/js/src/estimateAndSetComputeLimit.ts
@@ -32,12 +32,14 @@ type EstimateAndUpdateProvisoryComputeUnitLimitFactoryFunction = <
  *
  * @example
  * ```ts
- * const estimateComputeUnitLimit = estimateComputeUnitLimitFactory({ rpc });
- * const estimateAndUpdateProvisoryComputeUnitLimit =
- *   estimateAndUpdateProvisoryComputeUnitLimitFactory(estimateComputeUnitLimit);
- * const estimatedTransactionMessage =
- *   await estimateAndUpdateProvisoryComputeUnitLimit(transactionMessage)
+ * const estimateAndUpdateCUs = estimateAndUpdateProvisoryComputeUnitLimitFactory(
+ *     estimateComputeUnitLimitFactory({ rpc })
+ * );
+ *
+ * const transactionMessageWithCUs = await estimateAndUpdateCUs(transactionMessage);
  * ```
+ *
+ * @see {@link estimateAndUpdateProvisoryComputeUnitLimitFactory}
  */
 export function estimateAndUpdateProvisoryComputeUnitLimitFactory(
   estimateComputeUnitLimit: EstimateComputeUnitLimitFactoryFunction

--- a/clients/js/src/estimateComputeLimit.ts
+++ b/clients/js/src/estimateComputeLimit.ts
@@ -41,13 +41,11 @@ import {
  * @example
  * ```ts
  * import { getSetComputeUnitLimitInstruction } from '@solana-program/compute-budget';
- * import { createSolanaRpc, getComputeUnitEstimateForTransactionMessageFactory, pipe } from '@solana/kit';
+ * import { createSolanaRpc, estimateComputeUnitLimitFactory, pipe } from '@solana/kit';
  *
  * // Create an estimator function.
  * const rpc = createSolanaRpc('http://127.0.0.1:8899');
- * const getComputeUnitEstimateForTransactionMessage = getComputeUnitEstimateForTransactionMessageFactory({
- *     rpc,
- * });
+ * const estimateComputeUnitLimit = estimateComputeUnitLimitFactory({ rpc });
  *
  * // Create your transaction message.
  * const transactionMessage = pipe(
@@ -57,11 +55,11 @@ import {
  *
  * // Request an estimate of the actual compute units this message will consume. This is done by
  * // simulating the transaction and grabbing the estimated compute units from the result.
- * const computeUnitsEstimate = await getComputeUnitEstimateForTransactionMessage(transactionMessage);
+ * const estimatedUnits = await estimateComputeUnitLimit(transactionMessage);
  *
  * // Set the transaction message's compute unit budget.
  * const transactionMessageWithComputeUnitLimit = prependTransactionMessageInstruction(
- *     getSetComputeUnitLimitInstruction({ units: computeUnitsEstimate }),
+ *     getSetComputeUnitLimitInstruction({ units: estimatedUnits }),
  *     transactionMessage,
  * );
  * ```

--- a/clients/js/src/estimateComputeLimit.ts
+++ b/clients/js/src/estimateComputeLimit.ts
@@ -1,0 +1,82 @@
+import {
+  estimateComputeUnitLimit,
+  EstimateComputeUnitLimitFactoryConfig,
+  EstimateComputeUnitLimitFactoryFunction,
+} from './estimateComputeLimitInternal';
+
+/**
+ * Use this utility to estimate the actual compute unit cost of a given transaction message.
+ *
+ * Correctly budgeting a compute unit limit for your transaction message can increase the
+ * probability that your transaction will be accepted for processing. If you don't declare a compute
+ * unit limit on your transaction, validators will assume an upper limit of 200K compute units (CU)
+ * per instruction.
+ *
+ * Since validators have an incentive to pack as many transactions into each block as possible, they
+ * may choose to include transactions that they know will fit into the remaining compute budget for
+ * the current block over transactions that might not. For this reason, you should set a compute
+ * unit limit on each of your transaction messages, whenever possible.
+ *
+ * > [!WARNING]
+ * > The compute unit estimate is just that -- an estimate. The compute unit consumption of the
+ * > actual transaction might be higher or lower than what was observed in simulation. Unless you
+ * > are confident that your particular transaction message will consume the same or fewer compute
+ * > units as was estimated, you might like to augment the estimate by either a fixed number of CUs
+ * > or a multiplier.
+ *
+ * > [!NOTE]
+ * > If you are preparing an _unsigned_ transaction, destined to be signed and submitted to the
+ * > network by a wallet, you might like to leave it up to the wallet to determine the compute unit
+ * > limit. Consider that the wallet might have a more global view of how many compute units certain
+ * > types of transactions consume, and might be able to make better estimates of an appropriate
+ * > compute unit budget.
+ *
+ * > [!INFO]
+ * > In the event that a transaction message does not already have a `SetComputeUnitLimit`
+ * > instruction, this function will add one before simulation. This ensures that the compute unit
+ * > consumption of the `SetComputeUnitLimit` instruction itself is included in the estimate.
+ *
+ * @param config
+ *
+ * @example
+ * ```ts
+ * import { getSetComputeUnitLimitInstruction } from '@solana-program/compute-budget';
+ * import { createSolanaRpc, getComputeUnitEstimateForTransactionMessageFactory, pipe } from '@solana/kit';
+ *
+ * // Create an estimator function.
+ * const rpc = createSolanaRpc('http://127.0.0.1:8899');
+ * const getComputeUnitEstimateForTransactionMessage = getComputeUnitEstimateForTransactionMessageFactory({
+ *     rpc,
+ * });
+ *
+ * // Create your transaction message.
+ * const transactionMessage = pipe(
+ *     createTransactionMessage({ version: 'legacy' }),
+ *     /* ... *\/
+ * );
+ *
+ * // Request an estimate of the actual compute units this message will consume. This is done by
+ * // simulating the transaction and grabbing the estimated compute units from the result.
+ * const computeUnitsEstimate = await getComputeUnitEstimateForTransactionMessage(transactionMessage);
+ *
+ * // Set the transaction message's compute unit budget.
+ * const transactionMessageWithComputeUnitLimit = prependTransactionMessageInstruction(
+ *     getSetComputeUnitLimitInstruction({ units: computeUnitsEstimate }),
+ *     transactionMessage,
+ * );
+ * ```
+ */
+export function estimateComputeUnitLimitFactory({
+  rpc,
+}: EstimateComputeUnitLimitFactoryConfig): EstimateComputeUnitLimitFactoryFunction {
+  return async function estimateComputeUnitLimitFactoryFunction(
+    transactionMessage,
+    config
+  ) {
+    return await estimateComputeUnitLimit({
+      ...config,
+      rpc,
+      transactionMessage,
+    });
+  };
+}

--- a/clients/js/src/estimateComputeLimitInternal.ts
+++ b/clients/js/src/estimateComputeLimitInternal.ts
@@ -1,0 +1,197 @@
+import {
+  Commitment,
+  CompilableTransactionMessage,
+  compileTransaction,
+  getBase64EncodedWireTransaction,
+  isDurableNonceTransaction,
+  isSolanaError,
+  ITransactionMessageWithFeePayer,
+  pipe,
+  Rpc,
+  SimulateTransactionApi,
+  Slot,
+  SOLANA_ERROR__TRANSACTION__FAILED_TO_ESTIMATE_COMPUTE_LIMIT,
+  SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
+  SolanaError,
+  Transaction,
+  TransactionMessage,
+} from '@solana/kit';
+import { updateOrAppendSetComputeUnitLimitInstruction } from './setComputeLimit';
+import { MAX_COMPUTE_UNIT_LIMIT } from './constants';
+import { fillMissingTransactionMessageLifetimeUsingProvisoryBlockhash } from './internalMoveToKit';
+
+export type EstimateComputeUnitLimitFactoryConfig = Readonly<{
+  /** An object that supports the {@link SimulateTransactionApi} of the Solana RPC API */
+  rpc: Rpc<SimulateTransactionApi>;
+}>;
+
+export type EstimateComputeUnitLimitFactoryFunction = (
+  transactionMessage:
+    | CompilableTransactionMessage
+    | (TransactionMessage & ITransactionMessageWithFeePayer),
+  config?: EstimateComputeUnitLimitFactoryFunctionConfig
+) => Promise<number>;
+
+export type EstimateComputeUnitLimitFactoryFunctionConfig = {
+  abortSignal?: AbortSignal;
+  /**
+   * Compute the estimate as of the highest slot that has reached this level of commitment.
+   *
+   * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+   * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+   * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+   * default commitment applied by the server is `"finalized"`.
+   */
+  commitment?: Commitment;
+  /**
+   * Prevents accessing stale data by enforcing that the RPC node has processed transactions up to
+   * this slot
+   */
+  minContextSlot?: Slot;
+};
+
+type EstimateComputeUnitLimitConfig =
+  EstimateComputeUnitLimitFactoryFunctionConfig &
+    Readonly<{
+      rpc: Rpc<SimulateTransactionApi>;
+      transactionMessage:
+        | CompilableTransactionMessage
+        | (TransactionMessage & ITransactionMessageWithFeePayer);
+    }>;
+
+/**
+ * Simulates a transaction message on the network and returns the number of compute units it
+ * consumed during simulation.
+ *
+ * The estimate this function returns can be used to set a compute unit limit on the transaction.
+ * Correctly budgeting a compute unit limit for your transaction message can increase the probability
+ * that your transaction will be accepted for processing.
+ *
+ * If you don't declare a compute unit limit on your transaction, validators will assume an upper
+ * limit of 200K compute units (CU) per instruction. Since validators have an incentive to pack as
+ * many transactions into each block as possible, they may choose to include transactions that they
+ * know will fit into the remaining compute budget for the current block over transactions that
+ * might not. For this reason, you should set a compute unit limit on each of your transaction
+ * messages, whenever possible.
+ *
+ * ## Example
+ *
+ * ```ts
+ * import { getSetComputeLimitInstruction } from '@solana-program/compute-budget';
+ * import { createSolanaRpc, getComputeUnitEstimateForTransactionMessageFactory, pipe } from '@solana/kit';
+ *
+ * // Create an estimator function.
+ * const rpc = createSolanaRpc('http://127.0.0.1:8899');
+ * const getComputeUnitEstimateForTransactionMessage =
+ *     getComputeUnitEstimateForTransactionMessageFactory({ rpc });
+ *
+ * // Create your transaction message.
+ * const transactionMessage = pipe(
+ *     createTransactionMessage({ version: 'legacy' }),
+ *     /* ... *\/
+ * );
+ *
+ * // Request an estimate of the actual compute units this message will consume.
+ * const computeUnitsEstimate =
+ *     await getComputeUnitEstimateForTransactionMessage(transactionMessage);
+ *
+ * // Set the transaction message's compute unit budget.
+ * const transactionMessageWithComputeUnitLimit = prependTransactionMessageInstruction(
+ *     getSetComputeLimitInstruction({ units: computeUnitsEstimate }),
+ *     transactionMessage,
+ * );
+ * ```
+ *
+ * > [!WARNING]
+ * > The compute unit estimate is just that &ndash; an estimate. The compute unit consumption of the
+ * > actual transaction might be higher or lower than what was observed in simulation. Unless you
+ * > are confident that your particular transaction message will consume the same or fewer compute
+ * > units as was estimated, you might like to augment the estimate by either a fixed number of CUs
+ * > or a multiplier.
+ *
+ * > [!NOTE]
+ * > If you are preparing an _unsigned_ transaction, destined to be signed and submitted to the
+ * > network by a wallet, you might like to leave it up to the wallet to determine the compute unit
+ * > limit. Consider that the wallet might have a more global view of how many compute units certain
+ * > types of transactions consume, and might be able to make better estimates of an appropriate
+ * > compute unit budget.
+ */
+export async function estimateComputeUnitLimit({
+  transactionMessage,
+  ...configs
+}: EstimateComputeUnitLimitConfig): Promise<number> {
+  const replaceRecentBlockhash = !isDurableNonceTransaction(transactionMessage);
+  const transaction = pipe(
+    transactionMessage,
+    fillMissingTransactionMessageLifetimeUsingProvisoryBlockhash,
+    (m) =>
+      updateOrAppendSetComputeUnitLimitInstruction(MAX_COMPUTE_UNIT_LIMIT, m),
+    compileTransaction
+  );
+
+  return await simulateTransactionAndGetConsumedUnits({
+    transaction,
+    replaceRecentBlockhash,
+    ...configs,
+  });
+}
+
+type SimulateTransactionAndGetConsumedUnitsConfig = Omit<
+  EstimateComputeUnitLimitConfig,
+  'transactionMessage'
+> &
+  Readonly<{ replaceRecentBlockhash?: boolean; transaction: Transaction }>;
+
+async function simulateTransactionAndGetConsumedUnits({
+  abortSignal,
+  rpc,
+  transaction,
+  ...simulateConfig
+}: SimulateTransactionAndGetConsumedUnitsConfig): Promise<number> {
+  const wireTransactionBytes = getBase64EncodedWireTransaction(transaction);
+
+  try {
+    const {
+      value: { err: transactionError, unitsConsumed },
+    } = await rpc
+      .simulateTransaction(wireTransactionBytes, {
+        ...simulateConfig,
+        encoding: 'base64',
+        sigVerify: false,
+      })
+      .send({ abortSignal });
+    if (unitsConsumed == null) {
+      // This should never be hit, because all RPCs should support `unitsConsumed` by now.
+      throw new SolanaError(
+        SOLANA_ERROR__TRANSACTION__FAILED_TO_ESTIMATE_COMPUTE_LIMIT
+      );
+    }
+    // FIXME(https://github.com/anza-xyz/agave/issues/1295): The simulation response returns
+    // compute units as a u64, but the `SetComputeLimit` instruction only accepts a u32. Until
+    // this changes, downcast it.
+    const downcastUnitsConsumed =
+      unitsConsumed > 4_294_967_295n ? 4_294_967_295 : Number(unitsConsumed);
+    if (transactionError) {
+      throw new SolanaError(
+        SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
+        {
+          cause: transactionError,
+          unitsConsumed: downcastUnitsConsumed,
+        }
+      );
+    }
+    return downcastUnitsConsumed;
+  } catch (e) {
+    if (
+      isSolanaError(
+        e,
+        SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT
+      )
+    )
+      throw e;
+    throw new SolanaError(
+      SOLANA_ERROR__TRANSACTION__FAILED_TO_ESTIMATE_COMPUTE_LIMIT,
+      { cause: e }
+    );
+  }
+}

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -1,1 +1,7 @@
 export * from './generated';
+
+export * from './constants';
+export * from './estimateAndSetComputeLimit';
+export * from './estimateComputeLimit';
+export * from './setComputeLimit';
+export * from './setComputePrice';

--- a/clients/js/src/internal.ts
+++ b/clients/js/src/internal.ts
@@ -1,0 +1,103 @@
+import {
+  BaseTransactionMessage,
+  getU32Decoder,
+  getU64Decoder,
+  IInstruction,
+  MicroLamports,
+  ReadonlyUint8Array,
+} from '@solana/kit';
+import {
+  COMPUTE_BUDGET_PROGRAM_ADDRESS,
+  ComputeBudgetInstruction,
+  identifyComputeBudgetInstruction,
+  SetComputeUnitLimitInstruction,
+  SetComputeUnitPriceInstruction,
+} from './generated';
+
+/**
+ * Finds the index of the first `SetComputeUnitLimit` instruction in a transaction message
+ * and its set limit, if any.
+ */
+export function getSetComputeUnitLimitInstructionIndexAndUnits(
+  transactionMessage: BaseTransactionMessage
+): { index: number; units: number } | null {
+  const index = getSetComputeUnitLimitInstructionIndex(transactionMessage);
+  if (index < 0) {
+    return null;
+  }
+
+  const units = getU32Decoder().decode(
+    transactionMessage.instructions[index].data as ReadonlyUint8Array,
+    1
+  );
+
+  return { index, units };
+}
+
+/**
+ * Finds the index of the first `SetComputeUnitLimit` instruction in a transaction message, if any.
+ */
+export function getSetComputeUnitLimitInstructionIndex(
+  transactionMessage: BaseTransactionMessage
+) {
+  return transactionMessage.instructions.findIndex(
+    isSetComputeUnitLimitInstruction
+  );
+}
+
+/**
+ * Checks if the given instruction is a `SetComputeUnitLimit` instruction.
+ */
+export function isSetComputeUnitLimitInstruction(
+  instruction: IInstruction
+): instruction is SetComputeUnitLimitInstruction {
+  return (
+    instruction.programAddress === COMPUTE_BUDGET_PROGRAM_ADDRESS &&
+    identifyComputeBudgetInstruction(instruction.data as Uint8Array) ===
+      ComputeBudgetInstruction.SetComputeUnitLimit
+  );
+}
+
+/**
+ * Finds the index of the first `SetComputeUnitPrice` instruction in a transaction message
+ * and its set micro-lamports, if any.
+ */
+export function getSetComputeUnitPriceInstructionIndexAndMicroLamports(
+  transactionMessage: BaseTransactionMessage
+): { index: number; microLamports: MicroLamports } | null {
+  const index = getSetComputeUnitPriceInstructionIndex(transactionMessage);
+  if (index < 0) {
+    return null;
+  }
+
+  const microLamports = getU64Decoder().decode(
+    transactionMessage.instructions[index].data as ReadonlyUint8Array,
+    1
+  ) as MicroLamports;
+
+  return { index, microLamports };
+}
+
+/**
+ * Finds the index of the first `SetComputeUnitPrice` instruction in a transaction message, if any.
+ */
+export function getSetComputeUnitPriceInstructionIndex(
+  transactionMessage: BaseTransactionMessage
+) {
+  return transactionMessage.instructions.findIndex(
+    isSetComputeUnitPriceInstruction
+  );
+}
+
+/**
+ * Checks if the given instruction is a `SetComputeUnitPrice` instruction.
+ */
+export function isSetComputeUnitPriceInstruction(
+  instruction: IInstruction
+): instruction is SetComputeUnitPriceInstruction {
+  return (
+    instruction.programAddress === COMPUTE_BUDGET_PROGRAM_ADDRESS &&
+    identifyComputeBudgetInstruction(instruction.data as Uint8Array) ===
+      ComputeBudgetInstruction.SetComputeUnitPrice
+  );
+}

--- a/clients/js/src/internalMoveToKit.ts
+++ b/clients/js/src/internalMoveToKit.ts
@@ -1,0 +1,65 @@
+// TODO: Add these helpers to @solana/kit in v3.
+
+import {
+  BaseTransactionMessage,
+  Blockhash,
+  setTransactionMessageLifetimeUsingBlockhash,
+  TransactionMessageWithBlockhashLifetime,
+  TransactionMessageWithDurableNonceLifetime,
+} from '@solana/kit';
+
+/**
+ * An invalid blockhash lifetime constraint used as a placeholder for
+ * transaction messages that are not yet ready to be compiled.
+ *
+ * This enables various operations on the transaction message, such as
+ * simulating it or calculating its transaction size, whilst defering
+ * the actual blockhash to a later stage.
+ */
+export const PROVISORY_BLOCKHASH_LIFETIME_CONSTRAINT: TransactionMessageWithBlockhashLifetime['lifetimeConstraint'] =
+  {
+    blockhash: '11111111111111111111111111111111' as Blockhash,
+    lastValidBlockHeight: 0n, // This is not included in compiled transactions; it can be anything.
+  };
+
+/**
+ * Sets a provisory blockhash lifetime constraint on the transaction message
+ * if and only if it doesn't already have a lifetime constraint.
+ */
+export function fillMissingTransactionMessageLifetimeUsingProvisoryBlockhash<
+  TTransactionMessage extends BaseTransactionMessage,
+>(
+  transactionMessage: TTransactionMessage
+): TTransactionMessage &
+  (
+    | TransactionMessageWithBlockhashLifetime
+    | TransactionMessageWithDurableNonceLifetime
+  ) {
+  type ReturnType = TTransactionMessage &
+    (
+      | TransactionMessageWithBlockhashLifetime
+      | TransactionMessageWithDurableNonceLifetime
+    );
+
+  if ('lifetimeConstraint' in transactionMessage) {
+    return transactionMessage as ReturnType;
+  }
+
+  return setTransactionMessageLifetimeUsingProvisoryBlockhash(
+    transactionMessage
+  );
+}
+
+/**
+ * Sets a provisory blockhash lifetime constraint on the transaction message.
+ */
+export function setTransactionMessageLifetimeUsingProvisoryBlockhash<
+  TTransactionMessage extends BaseTransactionMessage,
+>(
+  transactionMessage: TTransactionMessage
+): TTransactionMessage & TransactionMessageWithBlockhashLifetime {
+  return setTransactionMessageLifetimeUsingBlockhash(
+    PROVISORY_BLOCKHASH_LIFETIME_CONSTRAINT,
+    transactionMessage
+  );
+}

--- a/clients/js/src/setComputeLimit.ts
+++ b/clients/js/src/setComputeLimit.ts
@@ -10,6 +10,15 @@ import { getSetComputeUnitLimitInstructionIndexAndUnits } from './internal';
  * Appends a `SetComputeUnitLimit` instruction with a provisory
  * compute unit limit to a given transaction message
  * if and only if it does not already have one.
+ *
+ * @example
+ * ```ts
+ * const transactionMessage = pipe(
+ *   createTransactionMessage({ version: 0 }),
+ *   fillProvisorySetComputeUnitLimitInstruction,
+ *   // ...
+ * );
+ * ```
  */
 export function fillProvisorySetComputeUnitLimitInstruction<
   TTransactionMessage extends BaseTransactionMessage,
@@ -24,10 +33,20 @@ export function fillProvisorySetComputeUnitLimitInstruction<
 /**
  * Updates the first `SetComputeUnitLimit` instruction in a transaction message
  * with the given units, or appends a new instruction if none exists.
+ * A function of the current value can be provided instead of a static value.
  *
  * @param units - The new compute unit limit, or a function that takes the previous
  *                compute unit limit and returns the new limit.
  * @param transactionMessage - The transaction message to update.
+ *
+ * @example
+ * ```ts
+ * const updatedTransactionMessage = updateOrAppendSetComputeUnitLimitInstruction(
+ *   // E.g. Keep the current limit if it is set, otherwise set it to the maximum.
+ *   (currentUnits) => currentUnits === null ? MAX_COMPUTE_UNIT_LIMIT : currentUnits,
+ *   transactionMessage,
+ * );
+ * ```
  */
 export function updateOrAppendSetComputeUnitLimitInstruction<
   TTransactionMessage extends BaseTransactionMessage,

--- a/clients/js/src/setComputeLimit.ts
+++ b/clients/js/src/setComputeLimit.ts
@@ -1,0 +1,63 @@
+import {
+  appendTransactionMessageInstruction,
+  BaseTransactionMessage,
+} from '@solana/kit';
+import { PROVISORY_COMPUTE_UNIT_LIMIT } from './constants';
+import { getSetComputeUnitLimitInstruction } from './generated';
+import { getSetComputeUnitLimitInstructionIndexAndUnits } from './internal';
+
+/**
+ * Appends a `SetComputeUnitLimit` instruction with a provisory
+ * compute unit limit to a given transaction message
+ * if and only if it does not already have one.
+ */
+export function fillProvisorySetComputeUnitLimitInstruction<
+  TTransactionMessage extends BaseTransactionMessage,
+>(transactionMessage: TTransactionMessage) {
+  return updateOrAppendSetComputeUnitLimitInstruction(
+    (previousUnits) =>
+      previousUnits === null ? PROVISORY_COMPUTE_UNIT_LIMIT : previousUnits,
+    transactionMessage
+  );
+}
+
+/**
+ * Updates the first `SetComputeUnitLimit` instruction in a transaction message
+ * with the given units, or appends a new instruction if none exists.
+ *
+ * @param units - The new compute unit limit, or a function that takes the previous
+ *                compute unit limit and returns the new limit.
+ * @param transactionMessage - The transaction message to update.
+ */
+export function updateOrAppendSetComputeUnitLimitInstruction<
+  TTransactionMessage extends BaseTransactionMessage,
+>(
+  units: number | ((previousUnits: number | null) => number),
+  transactionMessage: TTransactionMessage
+): TTransactionMessage {
+  const getUnits = (previousUnits: number | null): number =>
+    typeof units === 'function' ? units(previousUnits) : units;
+  const instructionDetails =
+    getSetComputeUnitLimitInstructionIndexAndUnits(transactionMessage);
+
+  if (!instructionDetails) {
+    return appendTransactionMessageInstruction(
+      getSetComputeUnitLimitInstruction({ units: getUnits(null) }),
+      transactionMessage
+    );
+  }
+
+  const { index, units: previousUnits } = instructionDetails;
+  const newUnits = getUnits(previousUnits);
+  if (newUnits === previousUnits) {
+    return transactionMessage;
+  }
+
+  const newInstruction = getSetComputeUnitLimitInstruction({ units: newUnits });
+  const newInstructions = [...transactionMessage.instructions];
+  newInstructions.splice(index, 1, newInstruction);
+  return Object.freeze({
+    ...transactionMessage,
+    instructions: newInstructions,
+  });
+}

--- a/clients/js/src/setComputePrice.ts
+++ b/clients/js/src/setComputePrice.ts
@@ -1,0 +1,67 @@
+import {
+  appendTransactionMessageInstruction,
+  BaseTransactionMessage,
+  MicroLamports,
+} from '@solana/kit';
+import { getSetComputeUnitPriceInstruction } from './generated';
+import { getSetComputeUnitPriceInstructionIndexAndMicroLamports } from './internal';
+
+export function setTransactionMessageComputeUnitPrice<
+  TTransactionMessage extends BaseTransactionMessage,
+>(microLamports: number | bigint, transactionMessage: TTransactionMessage) {
+  return appendTransactionMessageInstruction(
+    getSetComputeUnitPriceInstruction({ microLamports }),
+    transactionMessage
+  );
+}
+
+/**
+ * Updates the first `SetComputeUnitPrice` instruction in a transaction message
+ * with the given units, or appends a new instruction if none exists.
+ *
+ * @param microLamports - The new compute unit price, or a function that
+ *                        takes the previous price and returns the new one.
+ * @param transactionMessage - The transaction message to update.
+ */
+export function updateOrAppendSetComputeUnitPriceInstruction<
+  TTransactionMessage extends BaseTransactionMessage,
+>(
+  microLamports:
+    | MicroLamports
+    | ((previousMicroLamports: MicroLamports | null) => MicroLamports),
+  transactionMessage: TTransactionMessage
+): TTransactionMessage {
+  const getMicroLamports = (
+    previousMicroLamports: MicroLamports | null
+  ): MicroLamports =>
+    typeof microLamports === 'function'
+      ? microLamports(previousMicroLamports)
+      : microLamports;
+  const instructionDetails =
+    getSetComputeUnitPriceInstructionIndexAndMicroLamports(transactionMessage);
+
+  if (!instructionDetails) {
+    return appendTransactionMessageInstruction(
+      getSetComputeUnitPriceInstruction({
+        microLamports: getMicroLamports(null),
+      }),
+      transactionMessage
+    );
+  }
+
+  const { index, microLamports: previousMicroLamports } = instructionDetails;
+  const newMicroLamports = getMicroLamports(previousMicroLamports);
+  if (newMicroLamports === previousMicroLamports) {
+    return transactionMessage;
+  }
+
+  const newInstruction = getSetComputeUnitPriceInstruction({
+    microLamports: newMicroLamports,
+  });
+  const newInstructions = [...transactionMessage.instructions];
+  newInstructions.splice(index, 1, newInstruction);
+  return Object.freeze({
+    ...transactionMessage,
+    instructions: newInstructions,
+  });
+}

--- a/clients/js/src/setComputePrice.ts
+++ b/clients/js/src/setComputePrice.ts
@@ -6,6 +6,18 @@ import {
 import { getSetComputeUnitPriceInstruction } from './generated';
 import { getSetComputeUnitPriceInstructionIndexAndMicroLamports } from './internal';
 
+/**
+ * Sets the compute unit price of a transaction message in micro-Lamports.
+ *
+ * @example
+ * ```ts
+ * const transactionMessage = pipe(
+ *   createTransactionMessage({ version: 0 }),
+ *   (m) => setTransactionMessageComputeUnitPrice(10_000, m),
+ *   // ...
+ * );
+ * ```
+ */
 export function setTransactionMessageComputeUnitPrice<
   TTransactionMessage extends BaseTransactionMessage,
 >(microLamports: number | bigint, transactionMessage: TTransactionMessage) {
@@ -17,11 +29,21 @@ export function setTransactionMessageComputeUnitPrice<
 
 /**
  * Updates the first `SetComputeUnitPrice` instruction in a transaction message
- * with the given units, or appends a new instruction if none exists.
+ * with the given micro-Lamports, or appends a new instruction if none exists.
+ * A function of the current value can be provided instead of a static value.
  *
  * @param microLamports - The new compute unit price, or a function that
  *                        takes the previous price and returns the new one.
  * @param transactionMessage - The transaction message to update.
+ *
+ * @example
+ * ```ts
+ * const updatedTransactionMessage = updateOrAppendSetComputeUnitPriceInstruction(
+ *   // E.g. double the current price or set it to 10_000 if it isn't set.
+ *   (currentPrice) => currentPrice === null ? 10_000 : currentPrice * 2,
+ *   transactionMessage,
+ * );
+ * ```
  */
 export function updateOrAppendSetComputeUnitPriceInstruction<
   TTransactionMessage extends BaseTransactionMessage,

--- a/clients/js/test/estimateAndSetComputeLimit.test.ts
+++ b/clients/js/test/estimateAndSetComputeLimit.test.ts
@@ -1,0 +1,148 @@
+import {
+  Address,
+  ITransactionMessageWithFeePayer,
+  Rpc,
+  SimulateTransactionApi,
+  TransactionMessage,
+} from '@solana/kit';
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import {
+  estimateAndUpdateProvisoryComputeUnitLimitFactory,
+  estimateComputeUnitLimitFactory,
+  getSetComputeUnitLimitInstruction,
+  MAX_COMPUTE_UNIT_LIMIT,
+  PROVISORY_COMPUTE_UNIT_LIMIT,
+} from '../src';
+
+const FOREVER_PROMISE = new Promise(() => {
+  /* never resolve */
+});
+
+describe('estimateAndUpdateProvisoryComputeUnitLimitFactory', () => {
+  let sendSimulateTransactionRequest: Mock;
+  let mockTransactionMessage: TransactionMessage &
+    ITransactionMessageWithFeePayer;
+  let rpc: Rpc<SimulateTransactionApi>;
+  let simulateTransaction: Mock;
+
+  beforeEach(() => {
+    mockTransactionMessage = {
+      feePayer: {
+        address: '7U8VWgTUucttJPt5Bbkt48WknWqRGBfstBt8qqLHnfPT' as Address,
+      },
+      instructions: [],
+      version: 0,
+    };
+    sendSimulateTransactionRequest = vi.fn().mockReturnValue(FOREVER_PROMISE);
+    simulateTransaction = vi.fn().mockReturnValue({
+      send: sendSimulateTransactionRequest,
+    });
+    rpc = { simulateTransaction };
+  });
+
+  it('appends a new SetComputeUnitLimit instruction if missing', async () => {
+    expect.assertions(1);
+    sendSimulateTransactionRequest.mockResolvedValue({
+      value: { unitsConsumed: 42n },
+    });
+    const estimateAndUpdate = estimateAndUpdateProvisoryComputeUnitLimitFactory(
+      estimateComputeUnitLimitFactory({ rpc })
+    );
+
+    const updatedTransactionMessage = await estimateAndUpdate(
+      mockTransactionMessage
+    );
+
+    expect(updatedTransactionMessage).toEqual({
+      ...mockTransactionMessage,
+      instructions: [getSetComputeUnitLimitInstruction({ units: 42 })],
+    });
+  });
+
+  it('updates the SetComputeUnitLimit instruction if set to PROVISORY_COMPUTE_UNIT_LIMIT', async () => {
+    expect.assertions(1);
+    sendSimulateTransactionRequest.mockResolvedValue({
+      value: { unitsConsumed: 42n },
+    });
+    const estimateAndUpdate = estimateAndUpdateProvisoryComputeUnitLimitFactory(
+      estimateComputeUnitLimitFactory({ rpc })
+    );
+
+    const updatedTransactionMessage = await estimateAndUpdate({
+      ...mockTransactionMessage,
+      instructions: [
+        getSetComputeUnitLimitInstruction({
+          units: PROVISORY_COMPUTE_UNIT_LIMIT,
+        }),
+      ],
+    });
+
+    expect(updatedTransactionMessage).toEqual({
+      ...mockTransactionMessage,
+      instructions: [getSetComputeUnitLimitInstruction({ units: 42 })],
+    });
+  });
+
+  it('updates the SetComputeUnitLimit instruction if set to MAX_COMPUTE_UNIT_LIMIT', async () => {
+    expect.assertions(1);
+    sendSimulateTransactionRequest.mockResolvedValue({
+      value: { unitsConsumed: 42n },
+    });
+    const estimateAndUpdate = estimateAndUpdateProvisoryComputeUnitLimitFactory(
+      estimateComputeUnitLimitFactory({ rpc })
+    );
+
+    const updatedTransactionMessage = await estimateAndUpdate({
+      ...mockTransactionMessage,
+      instructions: [
+        getSetComputeUnitLimitInstruction({
+          units: MAX_COMPUTE_UNIT_LIMIT,
+        }),
+      ],
+    });
+
+    expect(updatedTransactionMessage).toEqual({
+      ...mockTransactionMessage,
+      instructions: [getSetComputeUnitLimitInstruction({ units: 42 })],
+    });
+  });
+
+  it('does not update the SetComputeUnitLimit instruction if set to an explicit value', async () => {
+    expect.assertions(1);
+    sendSimulateTransactionRequest.mockResolvedValue({
+      value: { unitsConsumed: 42n },
+    });
+    const estimateAndUpdate = estimateAndUpdateProvisoryComputeUnitLimitFactory(
+      estimateComputeUnitLimitFactory({ rpc })
+    );
+
+    const updatedTransactionMessage = await estimateAndUpdate({
+      ...mockTransactionMessage,
+      instructions: [getSetComputeUnitLimitInstruction({ units: 123456 })],
+    });
+
+    expect(updatedTransactionMessage).toEqual({
+      ...mockTransactionMessage,
+      instructions: [getSetComputeUnitLimitInstruction({ units: 123456 })],
+    });
+  });
+
+  it('can be aborted', () => {
+    const abortController = new AbortController();
+    const estimateAndUpdate = estimateAndUpdateProvisoryComputeUnitLimitFactory(
+      estimateComputeUnitLimitFactory({ rpc })
+    );
+
+    estimateAndUpdate(mockTransactionMessage, {
+      abortSignal: abortController.signal,
+    }).catch(() => {});
+
+    expect(sendSimulateTransactionRequest).toHaveBeenCalledWith({
+      abortSignal: expect.objectContaining({ aborted: false }),
+    });
+    abortController.abort();
+    expect(sendSimulateTransactionRequest).toHaveBeenCalledWith({
+      abortSignal: expect.objectContaining({ aborted: true }),
+    });
+  });
+});

--- a/clients/js/test/estimateComputeLimitInternal.test.ts
+++ b/clients/js/test/estimateComputeLimitInternal.test.ts
@@ -1,0 +1,315 @@
+import {
+  AccountRole,
+  Address,
+  Blockhash,
+  ITransactionMessageWithFeePayer,
+  Nonce,
+  Rpc,
+  SimulateTransactionApi,
+  SOLANA_ERROR__INSTRUCTION_ERROR__INSUFFICIENT_FUNDS,
+  SOLANA_ERROR__TRANSACTION__FAILED_TO_ESTIMATE_COMPUTE_LIMIT,
+  SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
+  SolanaError,
+  TransactionError,
+  TransactionMessage,
+  compileTransaction,
+} from '@solana/kit';
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { estimateComputeUnitLimit } from '../src/estimateComputeLimitInternal';
+
+// Spy on the `compileTransaction` function.
+vi.mock('@solana/kit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@solana/kit')>();
+  return {
+    ...actual,
+    compileTransaction: vi.fn(actual.compileTransaction),
+  };
+});
+
+const FOREVER_PROMISE = new Promise(() => {
+  /* never resolve */
+});
+
+const MOCK_BLOCKHASH_LIFETIME_CONSTRAINT = {
+  blockhash: 'GNtuHnNyW68wviopST3ki37Afv7LPphxfSwiHAkX5Q9H' as Blockhash,
+  lastValidBlockHeight: 0n,
+} as const;
+
+describe('estimateComputeUnitLimit', () => {
+  let sendSimulateTransactionRequest: Mock;
+  let mockTransactionMessage: TransactionMessage &
+    ITransactionMessageWithFeePayer;
+  let rpc: Rpc<SimulateTransactionApi>;
+  let simulateTransaction: Mock;
+
+  beforeEach(() => {
+    mockTransactionMessage = {
+      feePayer: {
+        address: '7U8VWgTUucttJPt5Bbkt48WknWqRGBfstBt8qqLHnfPT' as Address,
+      },
+      instructions: [],
+      version: 0,
+    };
+    sendSimulateTransactionRequest = vi.fn().mockReturnValue(FOREVER_PROMISE);
+    simulateTransaction = vi.fn().mockReturnValue({
+      send: sendSimulateTransactionRequest,
+    });
+    rpc = { simulateTransaction };
+  });
+
+  it('aborts the `simulateTransaction` request when aborted', () => {
+    const abortController = new AbortController();
+    estimateComputeUnitLimit({
+      abortSignal: abortController.signal,
+      rpc,
+      transactionMessage: {
+        ...mockTransactionMessage,
+        lifetimeConstraint: MOCK_BLOCKHASH_LIFETIME_CONSTRAINT,
+      },
+    }).catch(() => {});
+
+    expect(sendSimulateTransactionRequest).toHaveBeenCalledWith({
+      abortSignal: expect.objectContaining({ aborted: false }),
+    });
+    abortController.abort();
+    expect(sendSimulateTransactionRequest).toHaveBeenCalledWith({
+      abortSignal: expect.objectContaining({ aborted: true }),
+    });
+  });
+
+  it('passes the expected basic input to the simulation request', () => {
+    estimateComputeUnitLimit({
+      commitment: 'finalized',
+      minContextSlot: 42n,
+      rpc,
+      transactionMessage: {
+        ...mockTransactionMessage,
+        lifetimeConstraint: MOCK_BLOCKHASH_LIFETIME_CONSTRAINT,
+      },
+    }).catch(() => {});
+
+    expect(simulateTransaction).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        commitment: 'finalized',
+        encoding: 'base64',
+        minContextSlot: 42n,
+        sigVerify: false,
+      })
+    );
+  });
+
+  it('appends a set compute unit limit instruction when one does not exist', () => {
+    const transactionMessage = {
+      ...mockTransactionMessage, // No `SetComputeUnitLimit` instruction
+      lifetimeConstraint: MOCK_BLOCKHASH_LIFETIME_CONSTRAINT,
+    };
+
+    estimateComputeUnitLimit({
+      rpc,
+      transactionMessage,
+    }).catch(() => {});
+
+    expect(compileTransaction).toHaveBeenCalledWith({
+      ...transactionMessage,
+      instructions: [
+        ...transactionMessage.instructions,
+        {
+          data:
+            // prettier-ignore
+            new Uint8Array([
+              0x02, // SetComputeUnitLimit instruction inde
+              0xc0, 0x5c, 0x15, 0x00, // 1,400,000, MAX_COMPUTE_UNITS
+            ]),
+          programAddress: 'ComputeBudget111111111111111111111111111111',
+        },
+      ],
+    });
+
+    vi.doUnmock('@solana/kit');
+  });
+
+  it('replaces the existing set compute unit limit instruction when one exists', () => {
+    const transactionMessage = {
+      ...mockTransactionMessage,
+      instructions: [
+        {
+          programAddress:
+            '4Kk4nA3F2nWHCcuyT8nR6oF7HQUQHmmzAVD5k8FQPKB2' as Address,
+        },
+        {
+          data:
+            // prettier-ignore
+            new Uint8Array([
+              0x02, // SetComputeUnitLimit instruction inde
+              0x01, 0x02, 0x03, 0x04, // ComputeUnits(u32)
+            ]),
+          programAddress:
+            'ComputeBudget111111111111111111111111111111' as Address,
+        },
+        {
+          programAddress:
+            '4Kk4nA3F2nWHCcuyT8nR6oF7HQUQHmmzAVD5k8FQPKB2' as Address,
+        },
+      ],
+      lifetimeConstraint: MOCK_BLOCKHASH_LIFETIME_CONSTRAINT,
+    };
+
+    estimateComputeUnitLimit({
+      rpc,
+      transactionMessage,
+    }).catch(() => {});
+
+    expect(compileTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instructions: [
+          transactionMessage.instructions[0],
+          {
+            ...transactionMessage.instructions[1],
+            data: new Uint8Array([0x02, 0xc0, 0x5c, 0x15, 0x00]), // Replaced with MAX_COMPUTE_UNITS
+          },
+          transactionMessage.instructions[2],
+        ],
+      })
+    );
+  });
+
+  it('does not ask for a replacement blockhash when the transaction message is a durable nonce transaction', () => {
+    estimateComputeUnitLimit({
+      rpc,
+      transactionMessage: {
+        ...mockTransactionMessage,
+        instructions: [
+          {
+            accounts: [
+              {
+                address:
+                  '7wJFRFuAE9x5Ptnz2VoBWsfecTCfuuM2sQCpECGypnTU' as Address,
+                role: AccountRole.WRITABLE,
+              },
+              {
+                address:
+                  'SysvarRecentB1ockHashes11111111111111111111' as Address,
+                role: AccountRole.READONLY,
+              },
+              {
+                address:
+                  'HzMoc78z1VNNf9nwD4Czt6CDYEb9LVD8KsVGP46FEmyJ' as Address,
+                role: AccountRole.READONLY_SIGNER,
+              },
+            ],
+            data: new Uint8Array([4, 0, 0, 0]),
+            programAddress: '11111111111111111111111111111111' as Address,
+          },
+        ],
+        lifetimeConstraint: {
+          nonce: 'BzAqD6382v5r1pcELoi8HWrBDV4dSL9NGemMn2JYAhxc' as Nonce,
+        },
+      },
+    }).catch(() => {});
+
+    expect(simulateTransaction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ replaceRecentBlockhash: false })
+    );
+  });
+
+  it('asks for a replacement blockhash even when the transaction message has a blockhash lifetime', () => {
+    estimateComputeUnitLimit({
+      rpc,
+      transactionMessage: {
+        ...mockTransactionMessage,
+        lifetimeConstraint: MOCK_BLOCKHASH_LIFETIME_CONSTRAINT,
+      },
+    }).catch(() => {});
+
+    expect(simulateTransaction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ replaceRecentBlockhash: true })
+    );
+  });
+
+  it('asks for a replacement blockhash when the transaction message has no lifetime', () => {
+    estimateComputeUnitLimit({
+      rpc,
+      transactionMessage: mockTransactionMessage,
+    }).catch(() => {});
+
+    expect(simulateTransaction).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ replaceRecentBlockhash: true })
+    );
+  });
+
+  it('returns the estimated compute units on success', async () => {
+    expect.assertions(1);
+    sendSimulateTransactionRequest.mockResolvedValue({
+      value: { unitsConsumed: 42n },
+    });
+
+    const estimatePromise = estimateComputeUnitLimit({
+      rpc,
+      transactionMessage: mockTransactionMessage,
+    });
+
+    await expect(estimatePromise).resolves.toBe(42);
+  });
+
+  it('caps the estimated compute units to MAX_COMPUTE_UNITS of 1.4M', async () => {
+    expect.assertions(1);
+    sendSimulateTransactionRequest.mockResolvedValue({
+      value: { unitsConsumed: 1400000n /* MAX_COMPUTE_UNITS */ },
+    });
+
+    const estimatePromise = estimateComputeUnitLimit({
+      rpc,
+      transactionMessage: mockTransactionMessage,
+    });
+
+    await expect(estimatePromise).resolves.toBe(1400000);
+  });
+
+  it('throws with the transaction error as cause when the transaction fails in simulation', async () => {
+    expect.assertions(1);
+    const transactionError: TransactionError = 'AccountNotFound';
+    sendSimulateTransactionRequest.mockResolvedValue({
+      value: { err: transactionError, unitsConsumed: 42n },
+    });
+
+    const estimatePromise = estimateComputeUnitLimit({
+      rpc,
+      transactionMessage: mockTransactionMessage,
+    });
+
+    await expect(estimatePromise).rejects.toThrow(
+      new SolanaError(
+        SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
+        {
+          cause: transactionError,
+          unitsConsumed: 42,
+        }
+      )
+    );
+  });
+
+  it('throws with the cause when simulation fails', async () => {
+    expect.assertions(1);
+    const simulationError = new SolanaError(
+      SOLANA_ERROR__INSTRUCTION_ERROR__INSUFFICIENT_FUNDS,
+      { index: 42 }
+    );
+    sendSimulateTransactionRequest.mockRejectedValue(simulationError);
+
+    const estimatePromise = estimateComputeUnitLimit({
+      rpc,
+      transactionMessage: mockTransactionMessage,
+    });
+
+    await expect(estimatePromise).rejects.toThrow(
+      new SolanaError(
+        SOLANA_ERROR__TRANSACTION__FAILED_TO_ESTIMATE_COMPUTE_LIMIT,
+        { cause: simulationError }
+      )
+    );
+  });
+});


### PR DESCRIPTION
This PR brings the following high-level helpers to the `@solana-program/compute-budget` JS client:
- const `MAX_COMPUTE_UNIT_LIMIT` (1_400_000): The maximum units assignable to a transaction. This can be used as a temporary value when simulating a transaction to estimate its actual CU.
- const `PROVISORY_COMPUTE_UNIT_LIMIT` (0): A temporary value that can be used to signal that the transaction should be simulated to get its CUs before being sent. It is safer to use than `MAX_COMPUTE_UNIT_LIMIT` because the transaction will fail to execute unless it is properly estimated.
- function `estimateComputeUnitLimitFactory`: Brought from `@solana/kit` and renamed it from `getComputeUnitEstimateForTransactionMessageFactory` since the function is now part of a narrower namespace (i.e. `@solana-program/compute-budget`). Aside from being renamed and refactored internally to use some more granular helpers, it works exactly the same. Tests were also brought from `@solana/kit` and converted from Jest to Vitest.
  
  ```ts
  const estimateCUs = estimateComputeUnitLimitFactory({ rpc });
  
  const estimatedCUs: number = await estimateCUs(transactionMessage);
  ```
- function `estimateAndUpdateProvisoryComputeUnitLimitFactory`: A slightly higher-level helper that accepts a function returned by `estimateComputeUnitLimitFactory` and return a function that estimates and updates the compute unit limit instruction if and only if it isn't already set to an explicit value (i.e. not `PROVISORY_COMPUTE_UNIT_LIMIT` nor `MAX_COMPUTE_UNIT_LIMIT`).
  
  ```ts
  const estimateAndUpdateCUs = estimateAndUpdateProvisoryComputeUnitLimitFactory(
      estimateComputeUnitLimitFactory({ rpc })
  );
  
  const transactionMessageWithCUs = await estimateAndUpdateCUs(transactionMessage);
  ```
- function `updateOrAppendSetComputeUnitLimitInstruction`: Updates the first `SetComputeUnitLimit` instruction in a transaction message with the given units, or appends a new instruction if none exists. A function of the current value can be provided instead of a static value.
  
  ```ts
  const updatedTransactionMessage = updateOrAppendSetComputeUnitLimitInstruction(
    // E.g. Keep the current limit if it is set, otherwise set it to the maximum.
    (currentUnits) => currentUnits === null ? MAX_COMPUTE_UNIT_LIMIT : currentUnits,
    transactionMessage,
  );
  ```
- function `fillProvisorySetComputeUnitLimitInstruction `: Appends a `SetComputeUnitLimit` instruction with a provisory compute unit limit to a given transaction message if and only if it does not already have one.
  
  ```ts
  const transactionMessage = pipe(
    createTransactionMessage({ version: 0 }),
    fillProvisorySetComputeUnitLimitInstruction,
    // ...
  );
  ```
- function `updateOrAppendSetComputeUnitPriceInstruction `: Updates the first `SetComputeUnitPrice` instruction in a transaction message with the given micro-Lamports, or appends a new instruction if none exists. A function of the current value can be provided instead of a static value.
  
  ```ts
  const updatedTransactionMessage = updateOrAppendSetComputeUnitPriceInstruction(
    // E.g. double the current price or set it to 10_000 if it isn't set.
    (currentPrice) => currentPrice === null ? 10_000 : currentPrice * 2,
    transactionMessage,
  );
  ```
- function `setTransactionMessageComputeUnitPrice `: Appends a `SetComputeUnitPrice` instruction with the provided micro-Lamports.
  
  ```ts
  const transactionMessage = pipe(
    createTransactionMessage({ version: 0 }),
    (m) => setTransactionMessageComputeUnitPrice(10_000, m),
    // ...
  );
  ```

Note that some of these helpers will be useful when configuring `TransactionPlanners` and `TransactionPlanExecutors` in the future. At this point, we may consider adding decorators for these types directly in this package.