### PR TITLE
Use SolanaError instance as CU simulation failure cause

### DIFF
--- a/clients/js/src/estimateComputeLimitInternal.ts
+++ b/clients/js/src/estimateComputeLimitInternal.ts
@@ -3,6 +3,7 @@ import {
     Commitment,
     compileTransaction,
     getBase64EncodedWireTransaction,
+    getSolanaErrorFromTransactionError,
     isSolanaError,
     isTransactionMessageWithDurableNonceLifetime,
     pipe,
@@ -158,7 +159,7 @@ async function simulateTransactionAndGetConsumedUnits({
         const downcastUnitsConsumed = unitsConsumed > 4_294_967_295n ? 4_294_967_295 : Number(unitsConsumed);
         if (transactionError) {
             throw new SolanaError(SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT, {
-                cause: transactionError,
+                cause: getSolanaErrorFromTransactionError(transactionError),
                 unitsConsumed: downcastUnitsConsumed,
             });
         }

--- a/clients/js/test/estimateComputeLimitInternal.test.ts
+++ b/clients/js/test/estimateComputeLimitInternal.test.ts
@@ -10,6 +10,7 @@ import {
     SOLANA_ERROR__INSTRUCTION_ERROR__INSUFFICIENT_FUNDS,
     SOLANA_ERROR__TRANSACTION__FAILED_TO_ESTIMATE_COMPUTE_LIMIT,
     SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
+    SOLANA_ERROR__TRANSACTION_ERROR__ACCOUNT_NOT_FOUND,
     SolanaError,
     TransactionError,
     TransactionMessageWithFeePayer,
@@ -235,7 +236,7 @@ describe('estimateComputeUnitLimit', () => {
         await expect(estimatePromise).resolves.toBe(1400000);
     });
 
-    it('throws with the transaction error as cause when the transaction fails in simulation', async () => {
+    it('throws with the transaction SolanaError as cause when the transaction fails in simulation', async () => {
         expect.assertions(1);
         const transactionError: TransactionError = 'AccountNotFound';
         sendSimulateTransactionRequest.mockResolvedValue({
@@ -249,7 +250,7 @@ describe('estimateComputeUnitLimit', () => {
 
         await expect(estimatePromise).rejects.toThrow(
             new SolanaError(SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT, {
-                cause: transactionError,
+                cause: new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__ACCOUNT_NOT_FOUND),
                 unitsConsumed: 42,
             }),
         );


### PR DESCRIPTION
Currently, the JavaScript client uses the `TransactionError` as-is as the cause of the `SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT` error.

This is inconsistent with how `@solana/kit` throws `SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE` errors which first converts the `TransactionError` into a `SolanaError` instance. This enables users to use the `@solana/errors` API when catching errors (e.g. via the `isSolanaError` helper).

This PR fixes this by also converting the `TransactionError` from the simulation into a `SolanaError` before using it as the `cause` of the parent error.

Relates to https://github.com/anza-xyz/kit-plugins/issues/25, https://github.com/anza-xyz/kit-plugins/pull/35 and https://github.com/anza-xyz/kit/pull/1230.