### PR TITLE
Expose helpers that identify compute instructions in a transaction

### DIFF
--- a/clients/js/src/estimateAndSetComputeLimit.ts
+++ b/clients/js/src/estimateAndSetComputeLimit.ts
@@ -4,7 +4,7 @@ import {
     EstimateComputeUnitLimitFactoryFunction,
     EstimateComputeUnitLimitFactoryFunctionConfig,
 } from './estimateComputeLimitInternal';
-import { getSetComputeUnitLimitInstructionIndexAndUnits } from './internal';
+import { findSetComputeUnitLimitInstructionIndexAndUnits } from './introspect';
 import { updateOrAppendSetComputeUnitLimitInstruction } from './setComputeLimit';
 
 type EstimateAndUpdateProvisoryComputeUnitLimitFactoryFunction = <
@@ -36,7 +36,7 @@ export function estimateAndUpdateProvisoryComputeUnitLimitFactory(
     estimateComputeUnitLimit: EstimateComputeUnitLimitFactoryFunction,
 ): EstimateAndUpdateProvisoryComputeUnitLimitFactoryFunction {
     return async function fn(transactionMessage, config) {
-        const instructionDetails = getSetComputeUnitLimitInstructionIndexAndUnits(transactionMessage);
+        const instructionDetails = findSetComputeUnitLimitInstructionIndexAndUnits(transactionMessage);
 
         // If the transaction message already has a compute unit limit instruction
         // which is set to a specific value — i.e. not 0 or the maximum limit —

--- a/clients/js/src/index.ts
+++ b/clients/js/src/index.ts
@@ -3,5 +3,6 @@ export * from './generated';
 export * from './constants';
 export * from './estimateAndSetComputeLimit';
 export * from './estimateComputeLimit';
+export * from './introspect';
 export * from './setComputeLimit';
 export * from './setComputePrice';

--- a/clients/js/src/introspect.ts
+++ b/clients/js/src/introspect.ts
@@ -18,10 +18,10 @@ import {
  * Finds the index of the first `SetComputeUnitLimit` instruction in a transaction message
  * and its set limit, if any.
  */
-export function getSetComputeUnitLimitInstructionIndexAndUnits(
+export function findSetComputeUnitLimitInstructionIndexAndUnits(
     transactionMessage: TransactionMessage,
 ): { index: number; units: number } | null {
-    const index = getSetComputeUnitLimitInstructionIndex(transactionMessage);
+    const index = transactionMessage.instructions.findIndex(isSetComputeUnitLimitInstruction);
     if (index < 0) {
         return null;
     }
@@ -29,13 +29,6 @@ export function getSetComputeUnitLimitInstructionIndexAndUnits(
     const units = getU32Decoder().decode(transactionMessage.instructions[index].data as ReadonlyUint8Array, 1);
 
     return { index, units };
-}
-
-/**
- * Finds the index of the first `SetComputeUnitLimit` instruction in a transaction message, if any.
- */
-export function getSetComputeUnitLimitInstructionIndex(transactionMessage: TransactionMessage) {
-    return transactionMessage.instructions.findIndex(isSetComputeUnitLimitInstruction);
 }
 
 /**
@@ -55,10 +48,10 @@ export function isSetComputeUnitLimitInstruction(
  * Finds the index of the first `SetComputeUnitPrice` instruction in a transaction message
  * and its set micro-lamports, if any.
  */
-export function getSetComputeUnitPriceInstructionIndexAndMicroLamports(
+export function findSetComputeUnitPriceInstructionIndexAndMicroLamports(
     transactionMessage: TransactionMessage,
 ): { index: number; microLamports: MicroLamports } | null {
-    const index = getSetComputeUnitPriceInstructionIndex(transactionMessage);
+    const index = transactionMessage.instructions.findIndex(isSetComputeUnitPriceInstruction);
     if (index < 0) {
         return null;
     }
@@ -72,18 +65,9 @@ export function getSetComputeUnitPriceInstructionIndexAndMicroLamports(
 }
 
 /**
- * Finds the index of the first `SetComputeUnitPrice` instruction in a transaction message, if any.
- */
-export function getSetComputeUnitPriceInstructionIndex(transactionMessage: TransactionMessage) {
-    return transactionMessage.instructions.findIndex(isSetComputeUnitPriceInstruction);
-}
-
-/**
  * Checks if the given instruction is a `SetComputeUnitPrice` instruction.
  */
-export function isSetComputeUnitPriceInstruction(
-    instruction: Instruction,
-): instruction is SetComputeUnitPriceInstruction {
+function isSetComputeUnitPriceInstruction(instruction: Instruction): instruction is SetComputeUnitPriceInstruction {
     return (
         instruction.programAddress === COMPUTE_BUDGET_PROGRAM_ADDRESS &&
         identifyComputeBudgetInstruction(instruction.data as Uint8Array) ===

--- a/clients/js/src/setComputeLimit.ts
+++ b/clients/js/src/setComputeLimit.ts
@@ -1,7 +1,7 @@
 import { appendTransactionMessageInstruction, TransactionMessage } from '@solana/kit';
 import { PROVISORY_COMPUTE_UNIT_LIMIT } from './constants';
 import { getSetComputeUnitLimitInstruction } from './generated';
-import { getSetComputeUnitLimitInstructionIndexAndUnits } from './internal';
+import { findSetComputeUnitLimitInstructionIndexAndUnits } from './introspect';
 
 /**
  * Appends a `SetComputeUnitLimit` instruction with a provisory
@@ -50,7 +50,7 @@ export function updateOrAppendSetComputeUnitLimitInstruction<TTransactionMessage
 ): TTransactionMessage {
     const getUnits = (previousUnits: number | null): number =>
         typeof units === 'function' ? units(previousUnits) : units;
-    const instructionDetails = getSetComputeUnitLimitInstructionIndexAndUnits(transactionMessage);
+    const instructionDetails = findSetComputeUnitLimitInstructionIndexAndUnits(transactionMessage);
 
     if (!instructionDetails) {
         return appendTransactionMessageInstruction(

--- a/clients/js/src/setComputePrice.ts
+++ b/clients/js/src/setComputePrice.ts
@@ -1,6 +1,6 @@
 import { appendTransactionMessageInstruction, TransactionMessage, MicroLamports } from '@solana/kit';
 import { getSetComputeUnitPriceInstruction } from './generated';
-import { getSetComputeUnitPriceInstructionIndexAndMicroLamports } from './internal';
+import { findSetComputeUnitPriceInstructionIndexAndMicroLamports } from './introspect';
 
 /**
  * Sets the compute unit price of a transaction message in micro-Lamports.
@@ -48,7 +48,7 @@ export function updateOrAppendSetComputeUnitPriceInstruction<TTransactionMessage
 ): TTransactionMessage {
     const getMicroLamports = (previousMicroLamports: MicroLamports | null): MicroLamports =>
         typeof microLamports === 'function' ? microLamports(previousMicroLamports) : microLamports;
-    const instructionDetails = getSetComputeUnitPriceInstructionIndexAndMicroLamports(transactionMessage);
+    const instructionDetails = findSetComputeUnitPriceInstructionIndexAndMicroLamports(transactionMessage);
 
     if (!instructionDetails) {
         return appendTransactionMessageInstruction(


### PR DESCRIPTION
This PR renames the `internal` folder to `introspect` (since it contains introspection helpers) and exports it from the main `index.ts` file to expose these helpers to the public. It also rename the `get` prefix from the exported helpers to `find` as it is more about finding instruction data in a transaction than getting it.