### PR TITLE
fix: include source files in published package for IDE navigation

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -16,7 +16,8 @@
     },
     "files": [
         "./dist/src",
-        "./dist/types"
+        "./dist/types",
+        "./src/"
     ],
     "scripts": {
         "build": "rimraf dist && tsup && tsc -p ./tsconfig.declarations.json",


### PR DESCRIPTION
## Problem

"Go to Definition" (Cmd+Click / F12) on any import from this package takes you to `.d.ts` type declarations instead of actual source code.

## Why

- `declarationMap: true` is set in tsconfig ✅
- `.d.ts.map` files reference source paths like `../../src/index.ts` ✅
- **Source files included in published npm package** ❌ — `files` only includes `./dist/src` and `./dist/types`

Declaration maps point to `../../src/` but that path doesn't exist in `node_modules`. IDE can't follow the map, falls back to `.d.ts`.

## Fix

Add `"./src/"` to the `files` array in `clients/js/package.json`. No build, tsconfig, or code changes.

## Size impact

- **npm install**: small increase (source files only)
- **App bundle size**: **zero impact** — bundlers resolve imports to compiled JS in `dist/` via `exports`/`main`/`module`

## Context

Same fix applied to `@solana/kit` ([anza-xyz/kit#1468](https://github.com/anza-xyz/kit/pull/1468)) and `@solana/kit-plugins`.