### PR TITLE
ci: bind publish package-path input via env before shell

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -54,9 +54,11 @@ jobs:
       - name: Compute variables
         id: compute
         shell: bash
+        env:
+          PACKAGE_PATH: ${{ inputs.package-path }}
         run: |
           echo "SOLANA_CLI_VERSION=$(make solana-cli-version)" >> "$GITHUB_OUTPUT"
-          TARGET=$(echo ${{ inputs.package-path }} | sed 's#/#-#')
+          TARGET=$(echo "$PACKAGE_PATH" | sed 's#/#-#')
           echo "TARGET=$TARGET" >> "$GITHUB_OUTPUT"
 
   main:

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -60,10 +60,12 @@ jobs:
       - name: Compute variables
         id: compute
         shell: bash
+        env:
+          PACKAGE_PATH: ${{ inputs['package-path'] }}
         run: |
           echo "RUST_TOOLCHAIN_NIGHTLY=$(make rust-toolchain-nightly)" >> "$GITHUB_OUTPUT"
           echo "SOLANA_CLI_VERSION=$(make solana-cli-version)" >> "$GITHUB_OUTPUT"
-          TARGET=$(echo ${{ inputs['package-path'] }} | sed 's#/#-#')
+          TARGET=$(echo "$PACKAGE_PATH" | sed 's#/#-#')
           echo "TARGET=$TARGET" >> "$GITHUB_OUTPUT"
 
   main:


### PR DESCRIPTION
## Summary
Bind `inputs.package-path` into step `env:` before shell use when computing `TARGET` in the publish-rust and publish-js workflows.

Keeps `${{ }}` expansions out of `run:` scripts.

## Test plan
- [ ] Confirm workflow YAML still validates
- [ ] Optional: dry-run publish workflows with a package-path input

Made with [Cursor](https://cursor.com)