### PR TITLE
Add clear signing display metadata to the IDL

### DIFF
--- a/idl.json
+++ b/idl.json
@@ -50,8 +50,7 @@
                 "unit": { "kind": "stringValueNode", "string": "SOL" }
               }
             },
-            "docs": ["Prioritization fee lamports."],
-            "display": { "kind": "structFieldDisplayNode", "label": "Additional fee" }
+            "docs": ["Prioritization fee lamports."]
           }
         ],
         "discriminators": [
@@ -104,7 +103,7 @@
               "Requested transaction-wide program heap size in bytes.",
               "Must be multiple of 1024. Applies to each program, including CPIs."
             ],
-            "display": { "kind": "structFieldDisplayNode", "label": "Heap size" }
+            "display": { "kind": "structFieldDisplayNode", "label": "Heap Size" }
           }
         ],
         "discriminators": [
@@ -154,7 +153,7 @@
               }
             },
             "docs": ["Transaction-wide compute unit limit."],
-            "display": { "kind": "structFieldDisplayNode", "label": "CU limit" }
+            "display": { "kind": "structFieldDisplayNode", "label": "CU Limit" }
           }
         ],
         "discriminators": [
@@ -206,7 +205,7 @@
             "docs": [
               "Transaction compute unit price used for prioritization fees."
             ],
-            "display": { "kind": "structFieldDisplayNode", "label": "CU price" }
+            "display": { "kind": "structFieldDisplayNode", "label": "CU Price" }
           }
         ],
         "discriminators": [
@@ -256,7 +255,7 @@
               }
             },
             "docs": [],
-            "display": { "kind": "structFieldDisplayNode", "label": "Data size limit" }
+            "display": { "kind": "structFieldDisplayNode", "label": "Data Size Limit" }
           }
         ],
         "discriminators": [

--- a/idl.json
+++ b/idl.json
@@ -19,7 +19,8 @@
             },
             "docs": [],
             "defaultValue": { "kind": "numberValueNode", "number": 0 },
-            "defaultValueStrategy": "omitted"
+            "defaultValueStrategy": "omitted",
+            "display": { "kind": "structFieldDisplayNode", "skip": "always" }
           },
           {
             "kind": "instructionArgumentNode",
@@ -27,9 +28,14 @@
             "type": {
               "kind": "numberTypeNode",
               "format": "u32",
-              "endian": "le"
+              "endian": "le",
+              "display": {
+                "kind": "amountNumberDisplayNode",
+                "unit": { "kind": "stringValueNode", "string": "CUs" }
+              }
             },
-            "docs": ["Units to request for transaction-wide compute."]
+            "docs": ["Units to request for transaction-wide compute."],
+            "display": { "kind": "structFieldDisplayNode", "label": "Requested CUs" }
           },
           {
             "kind": "instructionArgumentNode",
@@ -37,9 +43,15 @@
             "type": {
               "kind": "numberTypeNode",
               "format": "u32",
-              "endian": "le"
+              "endian": "le",
+              "display": {
+                "kind": "amountNumberDisplayNode",
+                "decimals": { "kind": "numberValueNode", "number": 9 },
+                "unit": { "kind": "stringValueNode", "string": "SOL" }
+              }
             },
-            "docs": ["Prioritization fee lamports."]
+            "docs": ["Prioritization fee lamports."],
+            "display": { "kind": "structFieldDisplayNode", "label": "Additional fee" }
           }
         ],
         "discriminators": [
@@ -52,7 +64,12 @@
         "name": "requestUnits",
         "idlName": "requestUnits",
         "docs": [],
-        "optionalAccountStrategy": "programId"
+        "optionalAccountStrategy": "programId",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Request compute units",
+          "interpolatedIntent": "Request ${data.units} for a fee of ${data.additionalFee}"
+        }
       },
       {
         "kind": "instructionNode",
@@ -68,7 +85,8 @@
             },
             "docs": [],
             "defaultValue": { "kind": "numberValueNode", "number": 1 },
-            "defaultValueStrategy": "omitted"
+            "defaultValueStrategy": "omitted",
+            "display": { "kind": "structFieldDisplayNode", "skip": "always" }
           },
           {
             "kind": "instructionArgumentNode",
@@ -76,12 +94,17 @@
             "type": {
               "kind": "numberTypeNode",
               "format": "u32",
-              "endian": "le"
+              "endian": "le",
+              "display": {
+                "kind": "amountNumberDisplayNode",
+                "unit": { "kind": "stringValueNode", "string": "bytes" }
+              }
             },
             "docs": [
               "Requested transaction-wide program heap size in bytes.",
               "Must be multiple of 1024. Applies to each program, including CPIs."
-            ]
+            ],
+            "display": { "kind": "structFieldDisplayNode", "label": "Heap size" }
           }
         ],
         "discriminators": [
@@ -94,7 +117,12 @@
         "name": "requestHeapFrame",
         "idlName": "requestHeapFrame",
         "docs": [],
-        "optionalAccountStrategy": "programId"
+        "optionalAccountStrategy": "programId",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Request heap frame",
+          "interpolatedIntent": "Request ${data.bytes} of program heap"
+        }
       },
       {
         "kind": "instructionNode",
@@ -110,7 +138,8 @@
             },
             "docs": [],
             "defaultValue": { "kind": "numberValueNode", "number": 2 },
-            "defaultValueStrategy": "omitted"
+            "defaultValueStrategy": "omitted",
+            "display": { "kind": "structFieldDisplayNode", "skip": "always" }
           },
           {
             "kind": "instructionArgumentNode",
@@ -118,9 +147,14 @@
             "type": {
               "kind": "numberTypeNode",
               "format": "u32",
-              "endian": "le"
+              "endian": "le",
+              "display": {
+                "kind": "amountNumberDisplayNode",
+                "unit": { "kind": "stringValueNode", "string": "CUs" }
+              }
             },
-            "docs": ["Transaction-wide compute unit limit."]
+            "docs": ["Transaction-wide compute unit limit."],
+            "display": { "kind": "structFieldDisplayNode", "label": "CU limit" }
           }
         ],
         "discriminators": [
@@ -133,7 +167,12 @@
         "name": "setComputeUnitLimit",
         "idlName": "setComputeUnitLimit",
         "docs": [],
-        "optionalAccountStrategy": "programId"
+        "optionalAccountStrategy": "programId",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Set compute unit limit",
+          "interpolatedIntent": "Set the compute unit limit to ${data.units}"
+        }
       },
       {
         "kind": "instructionNode",
@@ -149,7 +188,8 @@
             },
             "docs": [],
             "defaultValue": { "kind": "numberValueNode", "number": 3 },
-            "defaultValueStrategy": "omitted"
+            "defaultValueStrategy": "omitted",
+            "display": { "kind": "structFieldDisplayNode", "skip": "always" }
           },
           {
             "kind": "instructionArgumentNode",
@@ -157,11 +197,16 @@
             "type": {
               "kind": "numberTypeNode",
               "format": "u64",
-              "endian": "le"
+              "endian": "le",
+              "display": {
+                "kind": "amountNumberDisplayNode",
+                "unit": { "kind": "stringValueNode", "string": "micro-lamports/CU" }
+              }
             },
             "docs": [
               "Transaction compute unit price used for prioritization fees."
-            ]
+            ],
+            "display": { "kind": "structFieldDisplayNode", "label": "CU price" }
           }
         ],
         "discriminators": [
@@ -174,7 +219,12 @@
         "name": "setComputeUnitPrice",
         "idlName": "setComputeUnitPrice",
         "docs": [],
-        "optionalAccountStrategy": "programId"
+        "optionalAccountStrategy": "programId",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Set compute unit price",
+          "interpolatedIntent": "Set the compute unit price to ${data.microLamports}"
+        }
       },
       {
         "kind": "instructionNode",
@@ -190,7 +240,8 @@
             },
             "docs": [],
             "defaultValue": { "kind": "numberValueNode", "number": 4 },
-            "defaultValueStrategy": "omitted"
+            "defaultValueStrategy": "omitted",
+            "display": { "kind": "structFieldDisplayNode", "skip": "always" }
           },
           {
             "kind": "instructionArgumentNode",
@@ -198,9 +249,14 @@
             "type": {
               "kind": "numberTypeNode",
               "format": "u32",
-              "endian": "le"
+              "endian": "le",
+              "display": {
+                "kind": "amountNumberDisplayNode",
+                "unit": { "kind": "stringValueNode", "string": "bytes" }
+              }
             },
-            "docs": []
+            "docs": [],
+            "display": { "kind": "structFieldDisplayNode", "label": "Data size limit" }
           }
         ],
         "discriminators": [
@@ -213,7 +269,12 @@
         "name": "setLoadedAccountsDataSizeLimit",
         "idlName": "setLoadedAccountsDataSizeLimit",
         "docs": [],
-        "optionalAccountStrategy": "programId"
+        "optionalAccountStrategy": "programId",
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Set loaded accounts data size limit",
+          "interpolatedIntent": "Limit loaded accounts data to ${data.accountDataSizeLimit}"
+        }
       }
     ],
     "definedTypes": [],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "devDependencies": {
         "@codama/renderers-js": "^2.3.0",
         "@codama/renderers-rust": "^3.1.0",
-        "codama": "^1.8.0",
+        "codama": "^1.10.0",
         "typescript": "^5.9.3"
     },
     "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,16 +15,20 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0(typescript@5.9.3)
       codama:
-        specifier: ^1.8.0
-        version: 1.8.0
+        specifier: ^1.10.0
+        version: 1.10.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
 
 packages:
 
-  '@codama/cli@1.5.3':
-    resolution: {integrity: sha512-RgLwZ24sGkPDwaH3DovOY3e1VXPnPwDBXojYXyOzPmEjQ23yTKacrLa3Zlt/XjMsXv9cLOym5OheC+gG6GxIpg==}
+  '@codama/cli@1.6.0':
+    resolution: {integrity: sha512-68fam0kzWsKp2ip/LZn3kDyFjWcbzHExCuDgEHGTX8C0gSscMch/c4EgtTq7NsWKc1cse0GMC5WIxCFumroTyQ==}
+    hasBin: true
+
+  '@codama/errors@1.10.0':
+    resolution: {integrity: sha512-/qiWQcbPIsyFlP1LrLqJfHt1QNbkY2wtC4UxZyKLnuZtc62YPlgDrN2wp4wcfRuE/DC0n3Y6ZSwYUrDBZyAnvA==}
     hasBin: true
 
   '@codama/errors@1.7.0':
@@ -41,11 +45,17 @@ packages:
   '@codama/fragments@0.1.1':
     resolution: {integrity: sha512-+DeC2YklyYf+qjRkoTKeG6HFgwsW7hiQko7er18dgsxF15M316EwYL2W40nKDPWlEhB/iME+sZR5++VQPUO/6w==}
 
+  '@codama/node-types@1.10.0':
+    resolution: {integrity: sha512-fMoJQ8TgB9A5Pl+GA8ffhDbGK63cV1nrbDrYTgIhPDKeVqBSdkSAoAuAtvWfRd7X2ML73H6RRi6jZRJmo2xfHQ==}
+
   '@codama/node-types@1.7.0':
     resolution: {integrity: sha512-VDytcSgN6jOGEh4aJ1LgSnqCe1drSEUSdAeKOV92aU0MOYiDi2s2B18+Gx7dx40mex2GfVc3zamu7KGzTlxegA==}
 
   '@codama/node-types@1.8.0':
     resolution: {integrity: sha512-KE9K9jjEdeFKtDKRrjjm5YwEkg7l+YwoWiH2w1UXJL/x6P5uul6+O5WnGsJn8IFtBVSLN4hbD7YSsZ0/lktJxQ==}
+
+  '@codama/nodes@1.10.0':
+    resolution: {integrity: sha512-P3NXVw6kZq2VDb4wYU6zQ3xFksDqSuDYqp11P6Dpei9XIZZ11NtL2jBjBcqsIudGIx104bMgSo4SZ7Hlej056A==}
 
   '@codama/nodes@1.7.0':
     resolution: {integrity: sha512-PZ1zI+SbE1PEaGEka0KjdFrAJ7e9O0kPG4CCGYhjsqUo76OBbINRjNVx7pkP4r8Ksa2r/BLbVIfZV1M/n5J5Kg==}
@@ -67,8 +77,11 @@ packages:
     resolution: {integrity: sha512-E/GSUCuiIpFj+ij3NbduH/h3sNDo39Bq14vj2atxdbbrPmu4clWvIEjXtbmP03qhudH73TxbYO8dWg/NwRi18A==}
     engines: {node: '>=20.18.0'}
 
-  '@codama/validators@1.8.0':
-    resolution: {integrity: sha512-gDmS85DwWmT41+PWTlbBrkSopGKW4UPhEcX+SLb2fF/uXMpJQXcgLE8BE9Fr7/DO+M9yFtGOVrnfDSCwepORGg==}
+  '@codama/validators@1.10.0':
+    resolution: {integrity: sha512-5WH1IHmyVVG/9QThZsrVM2ROv5w3yLF/8+4HK/kr8uw0ZXnIBGidnmyrxr1P8V+X6DgZqKJaX46V30dSs/NOTQ==}
+
+  '@codama/visitors-core@1.10.0':
+    resolution: {integrity: sha512-8koBGs4m/NI4nDLJZx7Q1KzRUKkBy/GAnZq4xOEFGlhTvDCIAzEgo3biAhNFynGY45gzZJSX08QTDWKsPRjnaA==}
 
   '@codama/visitors-core@1.7.0':
     resolution: {integrity: sha512-ii1Z39ORzssMQdpxqpjaHCLbFwO4KZbI1SrsJ1e0r+0g03gxuYEA1H6RoxcrIOuUeOnqNtLb96cErrzHdrx23Q==}
@@ -76,8 +89,8 @@ packages:
   '@codama/visitors-core@1.8.0':
     resolution: {integrity: sha512-CLO0icVvzAutjI7imuN1Rib0/GIBc7hhwQ5gcE3aVAVBHUNS4M27BzagqYTpL0cMC9I1tL9c6lhpCBV2kKs6Zg==}
 
-  '@codama/visitors@1.8.0':
-    resolution: {integrity: sha512-vQ863YkHBdLWZeaiPKisiRe0bbuBEBe9xDWVcLCCLRsmKCQuS+GB4bKxIwrlTr9cxCOGyQLkI7B/yAqyYEdbmw==}
+  '@codama/visitors@1.10.0':
+    resolution: {integrity: sha512-xAGKosZQnXBo9MiHFipA9Dsec1k9nbpv5UgUyY1j3l85FGEZQT2tHqrNxtBmPrC3LNSLVOfAdiUUMVUXUX5ydA==}
 
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
@@ -144,8 +157,8 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
-  codama@1.8.0:
-    resolution: {integrity: sha512-P1hctEUpZfgjm3xfosrD4xo/SVnp17ONuGDDtBmkyOaJBBL2JkYXjomZF9xOQqhvlfgcgqRKNB96Lcs4MG/fLQ==}
+  codama@1.10.0:
+    resolution: {integrity: sha512-fH1wz1P6bbPOWNM23Sk4VzRSpqxRW1CpXNiWQY23vHT2tno/K1/JtaaUc7DS5ddl5rGFKtq9R2UFsegR96IxRQ==}
     hasBin: true
 
   commander@14.0.3:
@@ -265,14 +278,20 @@ packages:
 
 snapshots:
 
-  '@codama/cli@1.5.3':
+  '@codama/cli@1.6.0':
     dependencies:
-      '@codama/nodes': 1.8.0
-      '@codama/visitors': 1.8.0
-      '@codama/visitors-core': 1.8.0
+      '@codama/nodes': 1.10.0
+      '@codama/visitors': 1.10.0
+      '@codama/visitors-core': 1.10.0
       commander: 14.0.3
       picocolors: 1.1.1
       prompts: 2.4.2
+
+  '@codama/errors@1.10.0':
+    dependencies:
+      '@codama/node-types': 1.10.0
+      commander: 14.0.3
+      picocolors: 1.1.1
 
   '@codama/errors@1.7.0':
     dependencies:
@@ -294,9 +313,16 @@ snapshots:
     dependencies:
       '@codama/errors': 1.8.0
 
+  '@codama/node-types@1.10.0': {}
+
   '@codama/node-types@1.7.0': {}
 
   '@codama/node-types@1.8.0': {}
+
+  '@codama/nodes@1.10.0':
+    dependencies:
+      '@codama/errors': 1.10.0
+      '@codama/node-types': 1.10.0
 
   '@codama/nodes@1.7.0':
     dependencies:
@@ -350,11 +376,17 @@ snapshots:
       - fastestsmallesttextencoderdecoder
       - typescript
 
-  '@codama/validators@1.8.0':
+  '@codama/validators@1.10.0':
     dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/nodes': 1.8.0
-      '@codama/visitors-core': 1.8.0
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      '@codama/visitors-core': 1.10.0
+
+  '@codama/visitors-core@1.10.0':
+    dependencies:
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      json-stable-stringify: 1.3.0
 
   '@codama/visitors-core@1.7.0':
     dependencies:
@@ -368,11 +400,11 @@ snapshots:
       '@codama/nodes': 1.8.0
       json-stable-stringify: 1.3.0
 
-  '@codama/visitors@1.8.0':
+  '@codama/visitors@1.10.0':
     dependencies:
-      '@codama/errors': 1.8.0
-      '@codama/nodes': 1.8.0
-      '@codama/visitors-core': 1.8.0
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      '@codama/visitors-core': 1.10.0
 
   '@iarna/toml@2.2.5': {}
 
@@ -427,13 +459,13 @@ snapshots:
 
   chalk@5.6.2: {}
 
-  codama@1.8.0:
+  codama@1.10.0:
     dependencies:
-      '@codama/cli': 1.5.3
-      '@codama/errors': 1.8.0
-      '@codama/nodes': 1.8.0
-      '@codama/validators': 1.8.0
-      '@codama/visitors': 1.8.0
+      '@codama/cli': 1.6.0
+      '@codama/errors': 1.10.0
+      '@codama/nodes': 1.10.0
+      '@codama/validators': 1.10.0
+      '@codama/visitors': 1.10.0
 
   commander@14.0.3: {}
 


### PR DESCRIPTION
This PR enriches the Codama IDL with display metadata for clear signing, per [sRFC 39](https://github.com/solana-foundation/SRFCs/discussions/4), and bumps `codama` to `^1.10.0` (the display node types shipped in 1.9). All five instructions gain intents and interpolated intents; arguments gain labels and unit displays (`CUs`, `micro-lamports/CU`, `bytes`, and SOL scaling for the deprecated `requestUnits` fee); discriminators are hidden from the fallback list.

Sample renders via `@codama/dynamic-instructions`:

```
Set the compute unit limit to 200000 CUs
Set the compute unit price to 10000 micro-lamports/CU
Request 1000000 CUs for a fee of 0.000005 SOL
```

Clients were regenerated and are unaffected: renderers pass display metadata through untouched.